### PR TITLE
Extend selftest workflow to multiple runners

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -1,52 +1,39 @@
 on:
   pull_request:
+
 name: Self-test
 jobs:
-  self-test-ubuntu:
-    name: on Ubuntu
-    runs-on: ubuntu-latest
+
+  self-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu', 'macos', 'windows']
+
+    runs-on: ${{ matrix.os }}-latest
     steps:
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
+
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Install gotestfmt
         uses: ./
         with:
           token: ${{ secrets.GH_TOKEN }}
+
       - name: Run gotestfmt
         working-directory: testdata
-        run: go test -json -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: go test -json -v ./... 2>&1 | tee /tmp/gotest.${{ matrix.os }}.log | gotestfmt
+
       - name: Upload test log
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: test-log-ubuntu
-          path: /tmp/gotest.log
-          if-no-files-found: error
-  self-test-macos:
-    name: on MacOS
-    runs-on: macos-latest
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install gotestfmt
-        uses: ./
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Run gotestfmt
-        working-directory: testdata
-        run: go test -json -v ./... 2>&1 | tee ./gotest.log | gotestfmt
-      - name: Upload test log
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: test-log-macos
-          path: ./testdata/gotest.log
+          name: test-log-${{ matrix.os }}
+          path: /tmp/gotest.${{ matrix.os }}.log
           if-no-files-found: error


### PR DESCRIPTION
## Please describe the change you are making

I'm condensing the existing `self-test` and `self-test-macos` jobs into a single job that defines `runs-on` with a [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs). I'm also adding windows to the OS list so that now there is also a test case for windows runners. This should help catch errors like #4 and #8 by ensuring that gotestfmt can run on all the major OS runners for GitHub Actions.

## Your code will be released under [the MIT license](LICENSE.md). Are you in the position, and are you willing to release your code under this license?

Yup :)

Signed-off-by: Yuri Norwood <106889957+norwd@users.noreply.github.com>
