### PR TITLE
Separate windows step from *nix runners

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -30,18 +30,18 @@ jobs:
         if: matrix.os != 'windows'
         working-directory: testdata
         run: |
-          go test -json -v ./... 2>&1 | tee /tmp/gotest.${{ matrix.os }}.log | gotestfmt
+          go test -json -v ./... 2>&1 | tee gotest.${{ matrix.os }}.log | gotestfmt
 
       - name: Run gotestfmt (Windows)
         if: matrix.os == 'windows'
         working-directory: testdata
         run: |
-          go test -json -v ./... 2>&1 | Tee-Object /tmp/gotest.${{ matrix.os }}.log | gotestfmt
+          go test -json -v ./... 2>&1 | Tee-Object gotest.${{ matrix.os }}.log | gotestfmt
 
       - name: Upload test log
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: test-log-${{ matrix.os }}
-          path: /tmp/gotest.${{ matrix.os }}.log
+          path: gotest.${{ matrix.os }}.log
           if-no-files-found: error

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         os: ['ubuntu', 'macos', 'windows']
 
+    name: on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
     steps:
 

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -24,11 +24,19 @@ jobs:
       - name: Install gotestfmt
         uses: ./
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Run gotestfmt
+        if: matrix.os != 'windows'
         working-directory: testdata
-        run: go test -json -v ./... 2>&1 | tee /tmp/gotest.${{ matrix.os }}.log | gotestfmt
+        run: |
+          go test -json -v ./... 2>&1 | tee /tmp/gotest.${{ matrix.os }}.log | gotestfmt
+
+      - name: Run gotestfmt (Windows)
+        if: matrix.os == 'windows'
+        working-directory: testdata
+        run: |
+          go test -json -v ./... 2>&1 | Tee-Object /tmp/gotest.${{ matrix.os }}.log | gotestfmt
 
       - name: Upload test log
         uses: actions/upload-artifact@v3

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -44,5 +44,5 @@ jobs:
         if: always()
         with:
           name: test-log-${{ matrix.os }}
-          path: gotest.${{ matrix.os }}.log
+          path: testdata/gotest.${{ matrix.os }}.log
           if-no-files-found: error


### PR DESCRIPTION
This allows `bash` and `pwsh` syntax to be used separately to avoid having to write the test as a polyglot 😬

Also added `secrets.GITHUB_TOKEN` as a fallback in case the repo secret `secrets.GH_TOKEN` is not set up, e.g. in a fork.

Signed-off-by: Yuri Norwood <106889957+norwd@users.noreply.github.com>

## Your code will be released under [the MIT license](LICENSE.md). Are you in the position, and are you willing to release your code under this license?

Yup :)